### PR TITLE
Update Hex.swift

### DIFF
--- a/Tests/Bip39Tests/Hex.swift
+++ b/Tests/Bip39Tests/Hex.swift
@@ -30,7 +30,7 @@ extension Data {
     }
 }
 
-extension String {
+public extension String {
     var hex: Data? {
         return Data(hex: self)
     }


### PR DESCRIPTION
-Adding public keyword allows the test to succeed
- copying the tests to the bigger project is to keep an eye on changes and this is needed